### PR TITLE
display system_type in verbose mode

### DIFF
--- a/check_smpp.pl
+++ b/check_smpp.pl
@@ -190,7 +190,7 @@ sub check_options {
 	verb "from = $from";
 	verb "message = $message";
 	verb "port = $port";
-	verb "system_type = $sytem_type";
+	verb "system_type = $system_type";
 	verb "service_type = $service_type";
 	verb "data_coding = $data_coding";
 }


### PR DESCRIPTION
There was a typo in the bit of code for verbose output, so the system_type never displayed properly.
